### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Letta Python API library
 
+> [!WARNING]
+> **This package is deprecated.** New development should use the [Letta Agent SDK](https://github.com/letta-ai/letta-agent-sdk) ([documentation](https://docs.letta.com/agent-sdk)) instead. Python applications on the current platform use the [App Server WebSocket protocol](https://docs.letta.com/platform/app-server); the Agent SDK provides the supported client for it. This package is unmaintained and receives no new features.
+
 <!-- prettier-ignore -->
 [![PyPI version](https://img.shields.io/pypi/v/letta-client.svg?label=pypi%20(stable))](https://pypi.org/project/letta-client/)
 


### PR DESCRIPTION
## tl;dr

New users are still picking up `letta-client` because no public surface marks it deprecated. This adds a README banner stating the package is deprecated and pointing to the [Letta Agent SDK](https://github.com/letta-ai/letta-agent-sdk) ([docs](https://docs.letta.com/agent-sdk)) as the replacement. The README is consumed three ways — GitHub, the PyPI long description (`pyproject.toml` sets `dynamic = ["readme"]`), and the docs.letta.com/api/python page — so one banner covers all three.

Python callers on the current platform use the [App Server WebSocket protocol](https://docs.letta.com/platform/app-server) directly; the Agent SDK docs describe that path. The v1 SDK deprecation is already stated at https://docs.letta.com/v1-sdk.

## Review notes

- The banner intentionally sits above the badges so it is the first thing read on the PyPI page.
- This does not change any code or the published package version. The PyPI long description updates on the next release. A runtime `warnings.warn` on import is a possible follow-up but is a behavioral change beyond this README fix.

## Testing

No automated test is meaningful for this change; verified that the README renders as valid Markdown with the GitHub alert syntax and that no other file references the README heading structure.

## Breadcrumbs

- Requested by: Sarah Wooders (Slack, #software-factory)
- Letta conversation: [`conv-ee3c8d0a-7ed4-414d-b4eb-a501ea9b426c`](https://chat.letta.com/chat/agent-19babcc0-e958-41b0-81d8-00107f71deb7?conversation=conv-ee3c8d0a-7ed4-414d-b4eb-a501ea9b426c)
- Related: letta-ai/skills#90 (removes the skill that teaches this package), letta-ai/letta-node counterpart PR